### PR TITLE
Make snapshots independent of absolute path

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const findSimilar = require("./index");
+const findMatches = require("./index");
 
 const filename = process.argv[2];
 if (!filename) {
@@ -8,4 +8,4 @@ if (!filename) {
   process.exit(0);
 }
 
-findSimilar(process.cwd(), filename);
+findMatches(process.cwd(), filename);

--- a/bin.js
+++ b/bin.js
@@ -1,3 +1,11 @@
 #!/usr/bin/env node
 
-require("./index");
+const findSimilar = require("./index");
+
+const filename = process.argv[2];
+if (!filename) {
+  console.error("No filename specified");
+  process.exit(0);
+}
+
+findSimilar(process.cwd(), filename);

--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
 const { readFileSync } = require("fs");
+const path = require("path");
 const { parse } = require("babylon");
 const cpa = require("./lib/cpa");
 
-const filename = process.argv[2];
-if (!filename) {
-  console.error("No filename specified");
-  process.exit(0);
-}
-const input = readFileSync(filename, "utf-8");
+const getBundle = (context, file) =>
+  readFileSync(path.join(context, file), "utf-8");
 
-const ast = parse(input, {
-  sourceFilename: filename
-}).program;
+const findSimilar = (context, file) => {
+  const input = getBundle(context, file);
+  const ast = parse(input, {
+    sourceFilename: file
+  }).program;
+  return cpa.run(ast, file);
+};
 
-cpa.run(ast, filename);
+module.exports = findSimilar;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const cpa = require("./lib/cpa");
 const getBundle = (context, file) =>
   readFileSync(path.join(context, file), "utf-8");
 
-const findSimilar = (context, file) => {
+const findMatches = (context, file) => {
   const input = getBundle(context, file);
   const ast = parse(input, {
     sourceFilename: file
@@ -14,4 +14,4 @@ const findSimilar = (context, file) => {
   return cpa.run(ast, file);
 };
 
-module.exports = findSimilar;
+module.exports = findMatches;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -32,14 +32,13 @@ module.exports = class Reporter {
   }
 
   print(dupsMap) {
-    let filePath = this.getPath(this.file);
     if (dupsMap.size === 0) {
-      let message = `No matches found for ${filePath} \n`;
+      let message = `No matches found for ${this.file}\n`;
       this.log(message, "green", true);
       return;
     }
 
-    this.log(`\nPrinting matches for - ${filePath}\n\n`, "red", true);
+    this.log(`\nPrinting matches for - ${this.file}\n\n`, "red", true);
 
     for (const [source, dups] of dupsMap.entries()) {
       const { code: sourceCode } = generate(source, { comments: false });

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -32,13 +32,14 @@ module.exports = class Reporter {
   }
 
   print(dupsMap) {
+    let filePath = this.getPath(this.file);
     if (dupsMap.size === 0) {
-      let message = `No matches found for ${this.file}\n`;
+      let message = `No matches found for ${filePath}\n`;
       this.log(message, "green", true);
       return;
     }
 
-    this.log(`\nPrinting matches for - ${this.file}\n\n`, "red", true);
+    this.log(`\nPrinting matches for - ${filePath}\n\n`, "red", true);
 
     for (const [source, dups] of dupsMap.entries()) {
       const { code: sourceCode } = generate(source, { comments: false });

--- a/test/__mocks__/path.js
+++ b/test/__mocks__/path.js
@@ -1,0 +1,15 @@
+const path = jest.genMockFromModule('path');
+
+path.resolve = function(context, filename) {
+  return filename;
+}
+
+path.relative = function(context, filename) {
+  return filename;
+}
+
+path.join = function(a, b) {
+  return a + '/' + b;
+}
+
+module.exports = path;

--- a/test/__snapshots__/cpa.test.js.snap
+++ b/test/__snapshots__/cpa.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should print matches with largest subexpression in the tree 1`] = `
 "
-Printing matches for - /Users/vshanmugam/open-source/dedupe-code/match.js
+Printing matches for - match.js
 
 Found 2 matches
 
@@ -35,6 +35,6 @@ function test2() {
 `;
 
 exports[`should print no matches found 1`] = `
-"No matches found for /Users/vshanmugam/open-source/dedupe-code/nomatch.js 
+"No matches found for nomatch.js
 "
 `;

--- a/test/cpa.test.js
+++ b/test/cpa.test.js
@@ -1,21 +1,12 @@
 jest.mock("chalk");
+jest.mock('path');
 
-const cpa = require("../lib/cpa");
+const findSimilar = require("../");
 const { parse } = require("babylon");
 const path = require("path");
 const fs = require("fs");
+
 const fixturesDir = path.join(__dirname, "fixtures");
-
-const getBundle = file =>
-  fs.readFileSync(path.join(fixturesDir, file), "utf-8");
-
-const getOutput = file => {
-  const input = getBundle(file);
-  const ast = parse(input, {
-    sourceFilename: file
-  }).program;
-  return cpa.run(ast, file);
-};
 
 let result,
   write = process.stdout.write,
@@ -35,11 +26,11 @@ afterEach(() => {
 });
 
 test("should print no matches found", () => {
-  const noMatch = getOutput("nomatch.js");
+  const noMatch = findSimilar(fixturesDir, "nomatch.js");
   expect(result).toMatchSnapshot();
 });
 
 test("should print matches with largest subexpression in the tree", () => {
-  const match = getOutput("match.js");
+  const match = findSimilar(fixturesDir, "match.js");
   expect(result).toMatchSnapshot();
 });

--- a/test/cpa.test.js
+++ b/test/cpa.test.js
@@ -1,7 +1,7 @@
 jest.mock("chalk");
 jest.mock('path');
 
-const findSimilar = require("../");
+const findMatches = require("../");
 const { parse } = require("babylon");
 const path = require("path");
 const fs = require("fs");
@@ -26,11 +26,11 @@ afterEach(() => {
 });
 
 test("should print no matches found", () => {
-  const noMatch = findSimilar(fixturesDir, "nomatch.js");
+  const noMatch = findMatches(fixturesDir, "nomatch.js");
   expect(result).toMatchSnapshot();
 });
 
 test("should print matches with largest subexpression in the tree", () => {
-  const match = findSimilar(fixturesDir, "match.js");
+  const match = findMatches(fixturesDir, "match.js");
   expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
Hey! Love the idea of the project. 
Cloned it and tried to run the tests and they broke with snapshot errors.
Turns out the reporter shows absolute path in the report and that corresponds to your machine.

Fixed this by having the reporter only output given filepath. 
Not sure if this behaviour is consistent with your vision, but need somehow to make the tests work same on all machines. Open to other solutions
